### PR TITLE
Pkg 3889: initial feedstock, v12.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,7 @@ channels:
   - lc030263
 upload_channels:
   - lc030263
+
+upload_to_staging_channel_in_pr: False
+
+upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - lc030263
+upload_channels:
+  - lc030263

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,8 @@
+# The buildout of these CUDA packages is happening on a private channel for the moment,
+# while we wait for a redistribution license.
+# It also prevents uploading to our public staging channel.
+# The below can probably all be deleted next time the feedstock needs updating.
+
 channels:
   - lc030263
 upload_channels:
@@ -6,3 +11,10 @@ upload_channels:
 upload_to_staging_channel_in_pr: False
 
 upload_without_merge: True
+
+mark_private: True
+
+# don't skip existing
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,8 +49,8 @@ outputs:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - cuda-cccl_{{ target_platform }} =={{ version }}
         - cuda-cccl-impl =={{ impl_version }}
-      # run_constrained:
-      #   - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
     # Tests are defined at the top level, due to package/output name conflicts.
     about:
       home: https://developer.nvidia.com/cuda-toolkit
@@ -76,8 +76,8 @@ outputs:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
-      # run_constrained:
-      #   - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      run_constrained:
+        - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
         - test -d $PREFIX/targets/{{ target_name }}/lib      # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [osx]
+  skip: true  # [osx or (linux and s390x)]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,16 +41,16 @@ test:
 outputs:
   - name: cuda-cccl
     requirements:
-      build:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      # build:
+      #   - arm-variant * {{ arm_variant_type }}  # [aarch64]
       host:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
         - cuda-cccl_{{ target_platform }} =={{ version }}
         - cuda-cccl-impl =={{ impl_version }}
-      run_constrained:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      # run_constrained:
+      #   - arm-variant * {{ arm_variant_type }}  # [aarch64]
     # Tests are defined at the top level, due to package/output name conflicts.
     about:
       home: https://developer.nvidia.com/cuda-toolkit
@@ -70,14 +70,14 @@ outputs:
       - Library\lib\x64\cmake                      # [win]
       - Library\include\targets\{{ target_name }}  # [win]
     requirements:
-      build:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      # build:
+      #   - arm-variant * {{ arm_variant_type }}  # [aarch64]
       host:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
-      run_constrained:
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+      # run_constrained:
+      #   - arm-variant * {{ arm_variant_type }}  # [aarch64]
     test:
       commands:
         - test -d $PREFIX/targets/{{ target_name }}/lib      # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,8 @@ test:
   commands:
     - test -d $PREFIX/lib/cmake                      # [linux]
     - test -d $PREFIX/targets/{{ target_name }}/lib  # [linux]
+    - if not exist %LIBRARY_LIB%\{{ target_name }}\cmake exit 1    # [win]
+    - if not exist %LIBRARY_INC%\targets\{{ target_name }} exit 1  # [win]
 
 outputs:
   - name: cuda-cccl


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-3889](https://anaconda.atlassian.net/browse/PKG-3889) 

### Explanation of changes:

- Third package of CUDA 12.3 build, following [conda-forge's pattern](https://github.com/conda-forge/staged-recipes/issues/21382) which was developed in conjunction with Nvidia. I don't see a need to stage these then release them all at once. They won't cause a problem released one at a time.
- Please check the main branch too, this has just been forked
- Uploads to private anaconda.org channel because we don't have the license agreement for this signed yet
- Also removes things that aren't applicable in defaults



[PKG-3889]: https://anaconda.atlassian.net/browse/PKG-3889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ