### PR TITLE
Make sure all noarch packages are built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+# If we skip-existing, then the noarch packages aren't built for all channels, for some reason
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"


### PR DESCRIPTION
If we don't include this, all the noarch packages with different platform names aren't uploaded.