### PR TITLE
cuda-cccl v13.1.115

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,3 @@
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,5 @@
 arm_variant_type:
 - sbsa
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -169,7 +169,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/cuda-cccl-split-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,3 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
 #  - tegra         # [aarch64]
-
-c_compiler_version:    # [linux]
-  - 14.3.0             # [linux]
-cxx_compiler_version:  # [linux]
-  - 14.3.0             # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "cuda-cccl" %}
-{% set version = "13.0.85" %}
+{% set version = "13.1.78" %}
 {% set cccl_version = "3.0.1" %}
-{% set cuda_version = "13.0" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64 and arm_variant_type=="sbsa"]
@@ -26,10 +26,10 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cccl/{{ platform }}/cuda_cccl-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: ed845eae8c1767706b6ee91e40c608a03f6f633551a849b63f7346d32d73ee60  # [linux64]
-  sha256: eca22ded176804a78afcba3fe1909e7d473366ee1cb9f3784080df23bc8e74d5  # [aarch64 and arm_variant_type=="sbsa"]
+  sha256: e23c8847aa429431d7eb4ccb87ded5eecaa6ba92f7b4bbab90c75c6141e635a2  # [linux64]
+  sha256: 413c62583bced2e0f82ed927ac796b14f0bbd0eee47ddfc5c5dfc936fb13048e  # [aarch64 and arm_variant_type=="sbsa"]
   #sha256: 8c87c2db67130108861609eacd40d30ee109656a7765e5172eab71dd6da4c453  # [aarch64 and arm_variant_type=="tegra"]
-  sha256: f4f5187f7976d8057d76e1e04e72c8b7d0a2a22793107a671ad709b1d8d3408d  # [win]
+  sha256: 3ca35d067652a5cd53f32a77f5e61dacd0cad193572866d2f04e7d0ce567ed43  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-cccl" %}
 {% set version = "13.1.115" %}
-{% set cccl_version = "3.1.2" %}
+{% set cccl_version = "3.1.4" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-cccl" %}
 {% set version = "13.1.78" %}
-{% set cccl_version = "3.0.1" %}
+{% set cccl_version = "3.1.2" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cuda-cccl" %}
-{% set version = "13.1.78" %}
+{% set version = "13.1.115" %}
 {% set cccl_version = "3.1.2" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
@@ -26,10 +26,10 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_cccl/{{ platform }}/cuda_cccl-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: e23c8847aa429431d7eb4ccb87ded5eecaa6ba92f7b4bbab90c75c6141e635a2  # [linux64]
-  sha256: 413c62583bced2e0f82ed927ac796b14f0bbd0eee47ddfc5c5dfc936fb13048e  # [aarch64 and arm_variant_type=="sbsa"]
+  sha256: b0fff2704e59d4e6f6f4b7b5b64f96a7bf86760a5696fd6cb6936f8f9cd92d4c  # [linux64]
+  sha256: c636c7b427090ff8c5059d2f977506120921c3c750ebf2e90c464b04629a6585  # [aarch64 and arm_variant_type=="sbsa"]
   #sha256: 8c87c2db67130108861609eacd40d30ee109656a7765e5172eab71dd6da4c453  # [aarch64 and arm_variant_type=="tegra"]
-  sha256: 3ca35d067652a5cd53f32a77f5e61dacd0cad193572866d2f04e7d0ce567ed43  # [win]
+  sha256: 23dd0b6cde26c5a3c9a86e9e29f4067449e32e0e6e220c2a9ffbaeee32277db3  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
cuda-cccl 13.1.115

**Destination channel:** defaults

### Links

- [PKG-12001](https://anaconda.atlassian.net/browse/PKG-12001) 
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/cccl-feedstock/pull/8

### Explanation of changes:

- CUDA 13.1 release


[PKG-12001]: https://anaconda.atlassian.net/browse/PKG-12001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ