### PR TITLE
cuda-cccl v12.9.27

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
-  - tegra         # [aarch64]
+#  - tegra         # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,10 +65,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: 'CUDA C++ Core Libraries'
       description: |
         CUDA C++ Core Libraries
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
   - name: cuda-cccl_{{ target_platform }}
     build:
@@ -96,20 +98,24 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: 'CUDA C++ Core Libraries'
       description: |
         CUDA C++ Core Libraries
       doc_url: https://docs.nvidia.com/cuda/index.html
+      dev_url: https://docs.nvidia.com/cuda/index.html
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: 'CUDA C++ Core Libraries'
   description: |
     CUDA C++ Core Libraries
   doc_url: https://docs.nvidia.com/cuda/index.html
+  dev_url: https://docs.nvidia.com/cuda/index.html
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-cccl 12.9.27

**Destination channel:** defaults

### Links

- [PKG-12769](https://anaconda.atlassian.net/browse/PKG-12769) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Added `abs.yaml` as a staging channel usage template for future releases


[PKG-12769]: https://anaconda.atlassian.net/browse/PKG-12769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ